### PR TITLE
t/OPS-1668-add-joblib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,12 @@ def makeDockerImageVersion(){
   if(env.BRANCH_NAME == 'master'){
     return 'latest'
   }
-  return env.BRANCH_NAME
+  /* https://docs.docker.com/engine/reference/commandline/tag/
+   * A tag name must be valid ASCII and may contain lowercase and uppercase
+   * letters, digits, underscores, periods and dashes.  A tag name may not start
+   * with a period or a dash and may contain a maximum of 128 characters.
+   */
+  return env.BRANCH_NAME.replaceAll(/[^A-Za-z0-9_.-]/, '').replaceFirst(/^[.-]*/, '').take(128)
 }
 
 pipeline{

--- a/Packages_analytics.py2
+++ b/Packages_analytics.py2
@@ -1,3 +1,4 @@
 pandas==0.24.2
 psycopg2==2.8.5
 SQLAlchemy==1.3.16
+joblib==1.1.0


### PR DESCRIPTION
https://finmason.atlassian.net/browse/OPS-1668

Stephan mentioned the library is not found on https://finmason.atlassian.net/browse/OPS-1668?focusedCommentId=60124

---

- Add `joblib` version 1.1.0 to the python docker file. 
- The `tag` is `2.1.21`
